### PR TITLE
Add unit tests for chat server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "aioconsole>=0.8.1",
+    "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.3",
     "ruff>=0.9.7",
     "websockets>=15.0",
 ]

--- a/test_chat_server.py
+++ b/test_chat_server.py
@@ -1,0 +1,79 @@
+import pytest
+import pytest_asyncio
+import asyncio
+import websockets
+import json
+from chat_server import broadcast, CONNECTIONS, handle_connection
+
+
+@pytest_asyncio.fixture(scope="function")
+async def websocket_server():
+    """WebSocketサーバーのフィクスチャ"""
+    CONNECTIONS.clear()  # テスト前にコネクションをクリア
+    server = await websockets.serve(handle_connection, "localhost", 8765)
+    await asyncio.sleep(0.1)  # サーバーの起動を待つ
+    yield server
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_broadcast(websocket_server):
+    """ブロードキャスト機能のテスト"""
+    # テスト用のWebSocket接続を作成
+    ws = await websockets.connect("ws://localhost:8765")
+
+    # 入室メッセージをスキップ
+    await ws.recv()
+
+    # テストメッセージを送信
+    test_message = "Hello, World!"
+    test_sender = "TestUser"
+    await broadcast(test_message, test_sender)
+
+    # ブロードキャストされたメッセージを受信
+    received = await ws.recv()
+    message_data = json.loads(received)
+
+    # メッセージの内容を検証
+    assert message_data["type"] == "message"
+    assert message_data["sender"] == test_sender
+    assert message_data["content"] == test_message
+
+    # クリーンアップ
+    await ws.close()
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_client_connection(websocket_server):
+    """クライアント接続のテスト"""
+    # クライアント接続を確立
+    ws = await websockets.connect("ws://localhost:8765")
+
+    # 入室メッセージを受信して接続が確立されていることを確認
+    received = await ws.recv()
+    message_data = json.loads(received)
+    assert message_data["type"] == "message"
+    assert "入室しました" in message_data["content"]
+
+    # クリーンアップ
+    await ws.close()
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_multiple_clients(websocket_server):
+    """複数クライアントの同時接続テスト"""
+    # 複数のクライアントを接続
+    clients = []
+    for _ in range(3):
+        client = await websockets.connect("ws://localhost:8765")
+        # 入室メッセージを受信
+        received = await client.recv()
+        message_data = json.loads(received)
+        assert message_data["type"] == "message"
+        assert "入室しました" in message_data["content"]
+        clients.append(client)
+
+    # クリーンアップ
+    for client in clients:
+        await client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -12,11 +12,22 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
 name = "example"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aioconsole" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "websockets" },
 ]
@@ -24,8 +35,64 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aioconsole", specifier = ">=0.8.1" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "ruff", specifier = ">=0.9.7" },
     { name = "websockets", specifier = ">=15.0" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
 ]
 
 [[package]]


### PR DESCRIPTION
# 変更理由
チャットサーバー（chat_server.py）に対するユニットテストを追加し、コードの品質と信頼性を向上させます。

# 動作確認
- pytestを使用してテストを実行し、すべてのテストが成功することを確認
- ruffを使用してコードフォーマットとチェックを実行し、問題がないことを確認

テスト内容：
- ブロードキャスト機能のテスト
- クライアント接続の基本機能テスト
- 複数クライアントの同時接続テスト

# 参考リンク
なし
